### PR TITLE
Add filter options to list

### DIFF
--- a/src/bin/pwx.rs
+++ b/src/bin/pwx.rs
@@ -16,7 +16,6 @@ const USAGE: &'static str = "
 Usage: pwx [options] [<file>] list [-R URL] [-G GROUP] [-U USERNAME] [-T TITLE] [<filter>]
        pwx [options] [<file>] info
        pwx [options] [<file>] get <uuid> <name>
-       pwx [options] [<file>] set <uuid <name> <val>
        pwx (--help | --version)
 
 Options:
@@ -45,7 +44,6 @@ macro_rules! usage {
 struct Args {
     arg_file: String,
     arg_name: String,
-    arg_val: String,
     arg_uuid: String,
     arg_filter: String,
     flag_url: String,
@@ -53,7 +51,6 @@ struct Args {
     flag_username: String,
     flag_title: String,
     cmd_list: bool,
-    cmd_set: bool,
     cmd_get: bool,
     cmd_info: bool,
     flag_version: bool,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,7 +18,7 @@ use std::cmp::min;
 mod twofish;
 use twofish::Key;
 
-mod util;
+pub mod util;
 use util::{from_le32,stretch_pass};
 
 const PREAMBLE_SIZE:usize = 152;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,6 +25,27 @@ const PREAMBLE_SIZE:usize = 152;
 const SHA256_SIZE:usize = 32;
 const BLOCK_SIZE:usize = 16;
 
+const FIELDNAMES: &'static [(&'static str, u8)] = &[
+    ("group", 0x02),
+    ("title", 0x03),
+    ("username", 0x04),
+    ("notes", 0x05),
+    ("url", 0x0d),
+    ("command", 0x12),
+    ("email", 0x14),
+    ];
+
+/** Return type for field name */
+pub fn field2type(name: &str) -> Option<u8>
+{
+    for field in FIELDNAMES {
+        if name == field.0 {
+            return Some(field.1)
+        }
+    }
+    None
+}
+
 #[derive(Debug)]
 pub enum Fail {
     UnableToOpen(io::Error),

--- a/tests/test_pwx.rs
+++ b/tests/test_pwx.rs
@@ -78,3 +78,31 @@ fn list_filter() {
     assert_eq!(sout.trim().split('\n').count(), 1);
 }
 
+#[test]
+fn get() {
+    // URL
+    let output = pwxrun!("get", "43fe1d0e-b65f-4e48-9abf-a1c5a1beeee8", "url");
+    assert!(output.status.success());
+    let sout = String::from_utf8_lossy(&output.stdout);
+    println!("{}", sout);
+    assert_eq!(sout.trim(), "https://facebook.com");
+
+    // Group
+    let output = pwxrun!("get", "43fe1d0e-b65f-4e48-9abf-a1c5a1beeee8", "group");
+    assert!(output.status.success());
+    let sout = String::from_utf8_lossy(&output.stdout);
+    println!("{}", sout);
+    assert_eq!(sout.trim(), "social");
+
+    // Group
+    let output = pwxrun!("get", "43fe1d0e-b65f-4e48-9abf-a1c5a1beeee8", "notes");
+    assert!(output.status.success());
+    let sout = String::from_utf8_lossy(&output.stdout);
+    println!("{}", sout);
+    assert_eq!(sout.trim(), "Some notes");
+
+    // Command is not set so the command fails
+    let output = pwxrun!("get", "43fe1d0e-b65f-4e48-9abf-a1c5a1beeee8", "command");
+    assert!(!output.status.success());
+}
+

--- a/tests/test_pwx.rs
+++ b/tests/test_pwx.rs
@@ -1,0 +1,80 @@
+//
+// Tests for the pwx binary
+//
+
+use std::process::Command;
+
+// TODO: Find a better way to get pwx binary path
+const PWXBIN: &'static str = "target/debug/pwx";
+
+macro_rules! pwxrun {
+    ($($arg:expr),*) => {
+        Command::new(PWXBIN)
+            .env("PWX_PASSWORD", "test")
+            .env("PWX_DATABASE", "tests/test.psafe3")
+            $(.arg($arg))*
+            .output().unwrap_or_else(|e| {panic!("Failed to execute pwx({}) {}", PWXBIN, e)})
+    };
+}
+
+/* Show all entries in the DB */
+#[test]
+fn list() {
+    let output = pwxrun!("list");
+    let sout = String::from_utf8_lossy(&output.stdout);
+    println!("{}", sout);
+    assert_eq!(sout.trim().split('\n').count(), 2);
+}
+
+/* Filter by title */
+#[test]
+fn list_title() {
+    let output = pwxrun!("list", "-T", "face");
+    let sout = String::from_utf8_lossy(&output.stdout);
+    println!("{}", sout);
+    assert_eq!(sout.trim().split('\n').count(), 1);
+}
+
+/* Filter by User */
+#[test]
+fn list_user() {
+    let output = pwxrun!("list", "-U", "testuser");
+    let sout = String::from_utf8_lossy(&output.stdout);
+    println!("{}", sout);
+    assert_eq!(sout.trim().split('\n').count(), 1);
+}
+
+/* Filter by Group */
+#[test]
+fn list_group() {
+    let output = pwxrun!("list", "-G", "social");
+    let sout = String::from_utf8_lossy(&output.stdout);
+    println!("{}", sout);
+    assert_eq!(sout.trim().split('\n').count(), 1);
+    assert!(sout.contains("facebook"));
+}
+
+/* Filter by URL */
+#[test]
+fn list_url() {
+    let output = pwxrun!("list", "-R", "facebook.com");
+    let sout = String::from_utf8_lossy(&output.stdout);
+    println!("{}", sout);
+    assert_eq!(sout.trim().split('\n').count(), 1);
+}
+
+/* list <filter> searches all text fields */
+#[test]
+fn list_filter() {
+    let output = pwxrun!("list", "some");
+    let sout = String::from_utf8_lossy(&output.stdout);
+    println!("{}", sout);
+    assert_eq!(sout.trim().split('\n').count(), 2);
+
+    // Filters 
+    let output = pwxrun!("list", "-U", "some", "some");
+    let sout = String::from_utf8_lossy(&output.stdout);
+    println!("{}", sout);
+    assert_eq!(sout.trim().split('\n').count(), 1);
+}
+


### PR DESCRIPTION
The *list* command now accepts optional filters to restrict the
records. Currents filters are URL, GROUP, USERNAME and TITLE. Filter
matching is slightly fuzzy - it actually is a case insensitive substr.